### PR TITLE
Changed footer position from fixed to relative

### DIFF
--- a/lib/public/css/screen.css
+++ b/lib/public/css/screen.css
@@ -15,7 +15,7 @@ body {
   height: 12%;
 }
 .mastfoot {
-  position: fixed;
+  position: relative;
   left: 0px;
   bottom: 0px;
   height: 50px;


### PR DESCRIPTION
The footer previously was overlapping the other content, and if the page height was too small then made it impossible to see the content behind. `position:relative` makes it such that the content is stacked one after another.