### PR TITLE
Added more style, changed the 404 page to a generic error page

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -194,5 +194,8 @@ exports.index = (req, res) => {
 exports.notFound = (req, res) => res
     .status(404)
     .render('layouts/main', {
-        error: { message: 'Page not found!' }
+        error: {
+            code: 404,
+            message: 'Page not found!'
+        }
     });

--- a/lib/public/css/screen.css
+++ b/lib/public/css/screen.css
@@ -3,85 +3,100 @@
     color:white;
   }*/
 body {
-  width: 100%;
-  height: 100%;
-  background-image: radial-gradient(circle, #0f229e 0, #202a6b 120%);
-  font-family: "proxima-nova", -apple-system, BlinkMacSystemFont, "Segoe UI",
-  "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue",
-  "Arial", sans-serif;
+    width: 100%;
+    height: 100%;
+    background-image: radial-gradient(circle, #0f229e 0, #202a6b 120%);
+    font-family: "proxima-nova", -apple-system, BlinkMacSystemFont, "Segoe UI",
+    "Roboto", "Oxygen", "Ubuntu", "Cantarell", "Open Sans", "Helvetica Neue",
+    "Arial", sans-serif;
 }
 
-.spinner{
-  width: 40px;
-  height: 40px;
-  border: 5px solid #f3f3f3;
-  border-top: 5px solid #6b9eef;
-  border-radius: 100%;
-  position: relative;
-  margin: 50px;
-  animation: spin 1s infinite linear;
+.spinner {
+    width: 40px;
+    height: 40px;
+    border: 5px solid #f3f3f3;
+    border-top: 5px solid #6b9eef;
+    border-radius: 100%;
+    position: relative;
+    margin: 50px;
+    animation: spin 1s infinite linear;
 }
 
-#realContent{
-  position: relative;
-  bottom: 85px;
+#realContent {
+    position: relative;
+    bottom: 85px;
 }
 
-@keyframes spin{
-  from{
-    transform:
-      rotate(0deg);
-  }to{
-    transform:
-      rotate(360deg);
-  }
+@keyframes spin {
+    from {
+        transform: rotate(0deg);
+    }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 .img-circle {
-  border-radius: 50%;
-  border: 5px solid white;
-  width: 10%;
-  height: 10%;
+    border-radius: 50%;
+    border: 5px solid white;
+    width: 10%;
+    height: 10%;
 }
+
 .mastfoot {
-  position: fixed;
-  left: 0px;
-  bottom: 0px;
-  height: 5%;
-  width: 100%;
-  text-transform: uppercase;
-  background-color: #444547;
-  padding-top: 8px;
-  font-size: 0.8em;
+    position: fixed;
+    left: 0px;
+    bottom: 0px;
+    height: 5%;
+    width: 100%;
+    text-transform: uppercase;
+    background-color: #444547;
+    padding-top: 8px;
+    font-size: 0.8em;
 }
-#search-form input{
-  padding: 10px;
-  border: none;
-  outline: none;
-  font-size: 1.4em;
-  border-radius: 35px;
-  border-top-right-radius: 0px;
-  border-bottom-right-radius: 0px;
-  text-align: center;
+
+#search-form input {
+    padding: 10px;
+    border: none;
+    outline: none;
+    font-size: 1.4em;
+    border-radius: 35px;
+    border-top-right-radius: 0px;
+    border-bottom-right-radius: 0px;
+    text-align: center;
 }
-#search-form button{
-  border-top-right-radius: 35px;
-  border-bottom-right-radius: 35px;
-  background-color: #0275d8;
-  color: white;
-  cursor: pointer;
+
+#search-form button {
+    border-top-right-radius: 35px;
+    border-bottom-right-radius: 35px;
+    background-color: #0275d8;
+    color: white;
+    cursor: pointer;
 }
+
 .result,
 h3 {
-  color: white;
+    color: white;
 }
+
 #canvas-container {
-  height: 400px;
-  max-width: 680px
+    height: 400px;
+    max-width: 680px
 }
+
 a .username {
-  color: white;
+    color: white;
 }
+
 .result {
-  margin-bottom: 5%;
+    margin-bottom: 5%;
+}
+
+/*
+Styles for the 404 page
+*/
+
+.error-container {
+    color: white;
+    padding-top: 20vh;
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -112,7 +112,6 @@
       "version": "1.0.9",
       "resolved": "http://r.cnpmjs.org/argparse/download/argparse-1.0.9.tgz",
       "integrity": "sha1-c9g7wmP4bpf4zE9rrhsOkKfSLIY=",
-
       "dev": true,
       "requires": {
         "sprintf-js": "1.0.3"
@@ -1169,7 +1168,6 @@
       "resolved": "http://r.cnpmjs.org/globby/download/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
       "dev": true,
-
       "requires": {
         "array-union": "1.0.2",
         "arrify": "1.0.1",
@@ -1282,6 +1280,12 @@
       "version": "0.4.19",
       "resolved": "http://r.cnpmjs.org/iconv-lite/download/iconv-lite-0.4.19.tgz",
       "integrity": "sha1-90aPYBNfXl2tM5nAqBvpoWA6CCs="
+    },
+    "ignore": {
+      "version": "3.3.5",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.5.tgz",
+      "integrity": "sha512-JLH93mL8amZQhh/p6mfQgVBH3M6epNq3DfsXsTSuSrInVjwyYlFE1nv2AgfRCC8PoOhM0jwQ5v8s9LgbK7yGDw==",
+      "dev": true
     },
     "ignore-by-default": {
       "version": "1.0.1",
@@ -2491,14 +2495,6 @@
         "duplexer": "0.1.1"
       }
     },
-    "string_decoder": {
-      "version": "1.0.3",
-      "resolved": "http://r.cnpmjs.org/string_decoder/download/string_decoder-1.0.3.tgz",
-      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
-    },
     "string-width": {
       "version": "2.1.1",
       "resolved": "http://r.cnpmjs.org/string-width/download/string-width-2.1.1.tgz",
@@ -2506,6 +2502,14 @@
       "requires": {
         "is-fullwidth-code-point": "2.0.0",
         "strip-ansi": "4.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.0.3",
+      "resolved": "http://r.cnpmjs.org/string_decoder/download/string_decoder-1.0.3.tgz",
+      "integrity": "sha1-D8Z9fBQYJd6UKC3VNr7GubzoYKs=",
+      "requires": {
+        "safe-buffer": "5.1.1"
       }
     },
     "stringstream": {

--- a/views/partials/404.handlebars
+++ b/views/partials/404.handlebars
@@ -1,10 +1,18 @@
-<div class="container text-center">
+<div class="container text-center error-container">
 
-  <!-- TODO: Design a better 404 page -->
-
-  <h1>Woops! Something went wrong!</h1>
-
-  <p>
-    {{error.message}}
+  <h1 class="display-3">Error {{error.code}} </h1>
+  <p class="lead">{{error.message}}</p>
+  <hr class="my-4">
+  <p>If you think you believe there is a bug please submit an <a
+    href="https://github.com/wildan3105/github-langs/issues" target="_blank">issue on GitHub</a>.</p>
+  <p class="lead">
+    <a class="btn btn-lg" href="/" role="button">Back to home</a>
   </p>
+
+</div>
+
+<div class="mastfoot">
+  <div class="inner text-center">
+    <p style="color:white">Disclaimer : This site is a fan made and not affiliated with GitHub.</p>
+  </div>
 </div>

--- a/views/partials/404.handlebars
+++ b/views/partials/404.handlebars
@@ -3,7 +3,7 @@
   <h1 class="display-3">Error {{error.code}} </h1>
   <p class="lead">{{error.message}}</p>
   <hr class="my-4">
-  <p>If you think you believe there is a bug please submit an <a
+  <p>If you think you believe there is a bug, please submit an <a
     href="https://github.com/wildan3105/github-langs/issues" target="_blank">issue on GitHub</a>.</p>
   <p class="lead">
     <a class="btn btn-lg" href="/" role="button">Back to home</a>


### PR DESCRIPTION
Added more style, changed the 404 page to a generic error page, now displays error.code and error.message.

Now with large white text, a link to creating an issue and a link to go back to the homepage, as well as the footer.

Didn't use an image since there's potentially codes other than 404

Fixes issue #36

### Changes: 

- Added some style to screen.css, changed the html layout a little, made use of Bootstrap 4.
- See the diff for details
- Non-intentionally re-indented the css file, my IDE did that, apologies. If needed I can revert that.

### Screenshots for the change:
![screenshot from 2017-10-12 17-08-22](https://user-images.githubusercontent.com/2358026/31493262-448b7674-af70-11e7-8a8f-e7a9c5d02e91.png)
![screenshot from 2017-10-12 17-08-49](https://user-images.githubusercontent.com/2358026/31493270-4b013e6c-af70-11e7-95c4-16de523821b9.png)
