### PR TITLE
Fix parsing when language is two words

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -119,7 +119,6 @@ exports.index = (req, res) => {
                         languages.unknown = languages.null;
                         delete languages.null;
                     }
-
                     const goodAt = _.maxBy(_.keys(languages), (o) => languages[o]);
                     const goodAtMysteryLanguage = (goodAt === 'unknown');
 
@@ -135,7 +134,7 @@ exports.index = (req, res) => {
                         username,
                         type,
                         avatar,
-                        languages,
+                        languages: JSON.stringify(languages),
                         showEmoji: getEmoji(numberOfRepos),
                         msg,
                         repos,
@@ -156,7 +155,7 @@ exports.index = (req, res) => {
                     username,
                     type,
                     avatar,
-                    languages,
+                    languages: JSON.stringify(languages),
                     msg,
                     repos,
                     statement

--- a/lib/public/js/chart.js
+++ b/lib/public/js/chart.js
@@ -22,7 +22,7 @@ const sum = (array) => {
 const chart = (limit) => {
     const color = 'white';
     const colorsArray = (new Array(limit)).fill(color);
-    const languages = parse(document.getElementById('canvas-container').dataset.languages);
+    const languages = JSON.parse(document.getElementById('canvas-container').dataset.languages);
     const keys = Object.keys(languages);
     const values = Object.values(languages);
     if (typeof limit !== 'number') {

--- a/views/partials/body.handlebars
+++ b/views/partials/body.handlebars
@@ -49,7 +49,7 @@
         </div>
         {{#if show.chart}}
         <div>
-          <div id="canvas-container" data-languages="{{#each languages}}{{@key}}:{{this}} {{/each}}">
+          <div id="canvas-container" data-languages='{{languages}}'>
             <canvas id="myChart"></canvas>
             {{#if limitLabel}}
             <span class="badge badge-pill badge-primary">For users with a lot of repo, only shown top 20 languages</span> {{/if}}


### PR DESCRIPTION
**Current behavior:**
if the language is two words it displays them separately with the other having `NaN` value
![screenshot from 2017-10-13 19-19-48](https://user-images.githubusercontent.com/14162336/31544128-e4c11c3a-b04b-11e7-9f9d-a8b872926b42.png)

**Expected behavior:**
the language with two words should be considered as one.

**Steps to reproduce:**
Go to the demo site and search for google or microsoft.



Changes: This fixes the issue above. 
`JSON.stringify(languages)` in backend and then `JSON.parse(languages)` in frontend. Looping through languages in handlebars no longer necessary. 


Screenshots for the change:
![screenshot from 2017-10-13 19-19-30](https://user-images.githubusercontent.com/14162336/31544174-1fce791c-b04c-11e7-9dc9-89775ad39df0.png)
