### PR TITLE
Updated footer to include copyright

### DIFF
--- a/views/partials/body.handlebars
+++ b/views/partials/body.handlebars
@@ -99,7 +99,7 @@
       {{/if}}
       <div class="mastfoot">
         <div class="inner">
-          <p style="color:white">Disclaimer : This site is a fan made and not affiliated with GitHub.</p>
+          <p style="color:white">Copyright © 2018 Wildan S. Nahar. All Rights Reserved. Disclaimer : This site is a fan made and not affiliated with GitHub.</p>
         </div>
       </div>
     </center>


### PR DESCRIPTION
Fixes issue #92 

Changes: Added copyright info

Screenshots for the change:
<img width="972" alt="image" src="https://user-images.githubusercontent.com/3247657/46713104-8eb54980-cc22-11e8-952f-e6e621f20e91.png">

