### PR TITLE
Add Copyright & Year to Footer

### DIFF
--- a/lib/controller.js
+++ b/lib/controller.js
@@ -62,7 +62,7 @@ const reqRepos = (username, numberOfPages) => {
 
 exports.index = (req, res) => {
     const { username } = req.query;
-    const currentYear = new Date().getFullYear()
+    const currentYear = new Date().getFullYear();
     let avatar, msg, repos, statement, type;
     let languages = {};
     const statements = [

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -62,6 +62,7 @@ const reqRepos = (username, numberOfPages) => {
 
 exports.index = (req, res) => {
     const { username } = req.query;
+    const currentYear = new Date().getFullYear()
     let avatar, msg, repos, statement, type;
     let languages = {};
     const statements = [
@@ -86,7 +87,8 @@ exports.index = (req, res) => {
             languages,
             msg,
             repos,
-            statement
+            statement,
+            currentYear
         });
         return;
     }
@@ -110,7 +112,8 @@ exports.index = (req, res) => {
                     msg,
                     repos,
                     showEmoji: getEmoji(numberOfRepos),
-                    statement
+                    statement,
+                    currentYear
                 });
                 return;
             }
@@ -152,7 +155,8 @@ exports.index = (req, res) => {
                         repos,
                         statement,
                         limitLabel,
-                        goodAt
+                        goodAt,
+                        currentYear
                     });
                 });
         })
@@ -171,7 +175,8 @@ exports.index = (req, res) => {
                     colors: JSON.stringify(getColors(languages)),
                     msg,
                     repos,
-                    statement
+                    statement,
+                    currentYear
                 });
                 return;
             }

--- a/views/partials/404.handlebars
+++ b/views/partials/404.handlebars
@@ -13,6 +13,6 @@
 
 <div class="mastfoot">
   <div class="inner text-center">
-    <p style="color:white">Disclaimer : This site is a fan made and not affiliated with GitHub.</p>
+    <p style="color:white"> Copyright &copy 2017 - {{currentYear}} Wildan S. Nahar | Disclaimer : This site is fan made and not affiliated with GitHub.</p>
   </div>
 </div>

--- a/views/partials/body.handlebars
+++ b/views/partials/body.handlebars
@@ -99,7 +99,7 @@
       {{/if}}
       <div class="mastfoot">
         <div class="inner">
-          <p style="color:white">Disclaimer : This site is a fan made and not affiliated with GitHub.</p>
+          <p style="color:white"> Copyright &copy 2017 - {{currentYear}} Wildan S. Nahar | Disclaimer : This site is fan made and not affiliated with GitHub.</p>
         </div>
       </div>
     </center>


### PR DESCRIPTION
Fixes issue #92 

Changes: Added Copyright and Current Year to the Footer for all all pages in handlebars in addition to Disclaimer. Added a currentYear const to controller to keep current copyright year up-to-date. Edited Disclaimer language to fix typo. 

Screenshots for the change:

![screen shot 2018-10-10 at 12 23 21 am](https://user-images.githubusercontent.com/36285885/46713170-fbc8df00-cc22-11e8-840c-5e84ab86c431.png)

