### PR TITLE
refactor: remove dotenv, use process.env instead for simplicity

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,8 @@ Let everyone know their languages statistic on github repo.
 ## GENERAL SETUP
 
 * [Generate a GitHub OAuth client id and client secret](https://github.com/settings/applications/new) to ensure you don't get rate limited API call.
-* Create `.env` file with this content :
 
+* Set `process.env` with these values:
 ```
 CLIENT_ID=your_client_id
 CLIENT_SECRET=your_client_secret

--- a/lib/controller.js
+++ b/lib/controller.js
@@ -1,18 +1,11 @@
 'use strict';
-const dotenv = require('dotenv');
 const _ = require('lodash');
 const axios = require('axios');
 
 const colorList = require('./public/json/colors.json');
 const error_messages = require('./config/error_messages');
 const { getEmoji, statements, mysteryStatements } = require('../lib/public/js/statements');
-const { error } = dotenv.config({ silent: true });
 const { GITHUB_API_URL } = require('./config/api');
-
-// load environment file
-if (error) {
-    console.warn(error.message);
-}
 
 const client_id = process.env.CLIENT_ID || false;
 const client_secret = process.env.CLIENT_SECRET || false;

--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "axios": "^0.19.0",
     "body-parser": "^1.15.1",
-    "dotenv": "~4.0.0",
     "express": "4.16.0",
     "express-handlebars": "3.0.0",
     "express-sslify": "1.2.0",


### PR DESCRIPTION
Changes: Remove `dotenv`, use native process.env instead.

